### PR TITLE
Fix mako issue to build on windows

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -21,7 +21,7 @@ export default defineConfig({
       : false,
   hash: true,
   mfsu: false,
-  mako: {},
+  mako: process.platform === 'win32' ? false : {},
   crossorigin: {},
   outputPath: '_site',
   favicons: ['https://gw.alipayobjects.com/zos/rmsportal/rlpTLlbMzTNYuZGGCVYM.png'],


### PR DESCRIPTION
When building on windows, an errer occurs.
The solution is to disable the mako option.
So If the build platform is windows, the mako option should be disabled.